### PR TITLE
Fixed lower/upper-case inconsistency of x, y.

### DIFF
--- a/kombagra/3roviny.tex
+++ b/kombagra/3roviny.tex
@@ -7,7 +7,7 @@
     \\$\forall K,L\in\mathcal{L},K\neq L : |K\cap L|=1$
     \item[(A2)]
     \textit{Každé dva různé body určují právě jednu přímku.}
-    \\$\forall x,y\in X,X\neq Y : \exists! L\in\mathcal{L} : \{x, y\}\subseteq L$
+    \\$\forall x,y\in X,x\neq y : \exists! L\in\mathcal{L} : \{x, y\}\subseteq L$
     \item[(A0)]
     \textit{Existuje čtveřice bodů taková, že žádné tři body z ní neleží na společné přímce.}
     \\$\exists Č\in\binom{X}{4}:\forall L\in\mathcal{L}:|Č\cap L|\leq 2$


### PR DESCRIPTION
Vzhledem k povaze axiomu je jasné, že tato řádka má říkat, že body x a y nejsou stejné. Body ovšem značíme malými písmeny a velké "X" je navíc rovnou množina bodů, tj. by výraz nedával takhle smysl (a Y není definované).